### PR TITLE
feat: Persist bash history in development container

### DIFF
--- a/.devcontainer/app/Dockerfile
+++ b/.devcontainer/app/Dockerfile
@@ -1,1 +1,10 @@
 FROM mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm
+
+ARG USERNAME=vscode
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && mkdir /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R $USERNAME /commandhistory \
+    && echo "$SNIPPET" >> "/home/$USERNAME/.bashrc"
+
+WORKDIR /workspaces/BlazorAzureADB2CApp1

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -5,12 +5,15 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ..:/workspaces:cached
+      - projectname-bashhistory:/commandhistory
     command: sleep infinity
     env_file: .env
     networks:
       - devnetwork
     init : true
 
+volumes:
+  projectname-bashhistory:
 
 #   db:
 #     build:

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,3 @@
 
 dotnet restore
-dotnet dev-certs https --clean &&dotnet dev-certs https --trust
+dotnet dev-certs https --clean && dotnet dev-certs https --trust


### PR DESCRIPTION
- bashの履歴を保持するため、コマンドヒストリーディレクトリを追加
- Dockerfileで履歴設定スニペットを.bashrcに追加
- compose.ymlにボリュームを設定して永続化を実現